### PR TITLE
Fix build errors caused when compiling with clang

### DIFF
--- a/src/fence.h
+++ b/src/fence.h
@@ -180,6 +180,8 @@ class fence_c {
         return m_rel_fence_list.cbegin();
       else if (ft == FENCE_FULL)
         return m_full_fence_list.cbegin();
+      else
+        assert(0);
     }
 
     list<int>::const_iterator cend(fence_type ft)
@@ -190,6 +192,8 @@ class fence_c {
         return m_rel_fence_list.cend();
       else if (ft == FENCE_FULL)
         return m_full_fence_list.cend();
+      else
+        assert(0);
     }
 };
 

--- a/src/trace_read_a64.cc
+++ b/src/trace_read_a64.cc
@@ -1496,6 +1496,8 @@ inst_info_s* a64_decoder_c::convert_pinuop_to_t_uop(void *trace_info, trace_uop_
         case ARM64_PRFM_PSTL3KEEP:
           trace_uop[0]->m_mem_type = MEM_SWPREF_T2;
           break;
+        default:
+          break;
         }
       }
 
@@ -1542,6 +1544,8 @@ inst_info_s* a64_decoder_c::convert_pinuop_to_t_uop(void *trace_info, trace_uop_
           case ARM64_PRFM_PLDL3KEEP:
           case ARM64_PRFM_PSTL3KEEP:
             trace_uop[1]->m_mem_type = MEM_SWPREF_T2;
+            break;
+          default:
             break;
           }
         } else {


### PR DESCRIPTION
Build error is caused by missing default case for switch and a missing return in
non-void function.
