### PR TITLE
add build action for CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: install scons
+      run: sudo apt install scons
     - name: default build
       run: ./build.py
     - name: build with dramsim

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,14 +10,20 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2
+
     - name: install scons
       run: sudo apt install scons
-    - name: default build
+    
+    - name: default opt build
       run: ./build.py
-    - name: build with dramsim
+    - name: default debug build
+      run: ./build.py -d
+    
+    - name: opt build with dramsim
       run: ./build.py --dramsim
+    - name: debug build with dramsim
+      run: ./build.py -d --dramsim

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,11 @@ name: build CI
 
 on:
   push:
-    branches: [ * ]
+    branches:
+      - '*'
   pull_request:
-    branches: [ * ]
+    branches:
+      - '*'
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,19 @@
+name: build CI
+
+on:
+  push:
+    branches: [ * ]
+  pull_request:
+    branches: [ * ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: default build
+      run: ./build.py
+    - name: build with dramsim
+      run: ./build.py --dramsim


### PR DESCRIPTION
this PR adds a build action on latest ubuntu release and tests the following 4 build cases: opt-build, debug-build, opt-build-with-dramsim, debug-build-with-dramsim.