### PR TITLE
Fix build error and update to python3

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -2,10 +2,10 @@
 
 === Requirement ===
 
-  SCons
+  SCons and dependencies
 
   * How to get SCons
-    Ubuntu --> apt-get install scons
+    Ubuntu --> apt-get install scons python-metaconfig
 
 
 === Build steps ===

--- a/SConscript
+++ b/SConscript
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 #########################################################################################
 # Author      : Jaekyu Lee (jq.lee17@gmail.com)
@@ -38,7 +38,7 @@ warn_flags = ' '.join(warn_flags)
 env = Environment()
 custom_vars = set(['AS', 'AR', 'CC', 'CXX', 'HOME', 'LD_LIBRARY_PATH', 'PATH', 'RANLIB'])
 
-for key,val in os.environ.iteritems():
+for key,val in os.environ.items():
   if key in custom_vars:
     env[key] = val
 

--- a/SConstruct
+++ b/SConstruct
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 #########################################################################################
 # Author      : Jaekyu Lee (jq.lee17@gmail.com)
@@ -8,7 +8,7 @@
 
 import os
 import sys
-import ConfigParser
+import configparser
 
 
 ## Check c++14 support
@@ -48,7 +48,7 @@ def pre_compile_check():
   env = Environment()
   custom_vars = set(['AS', 'AR', 'CC', 'CXX', 'HOME', 'LD_LIBRARY_PATH', 'PATH', 'RANLIB'])
 
-  for key,val in os.environ.iteritems():
+  for key,val in os.environ.items():
     if key in custom_vars:
       env[key] = val
 
@@ -68,17 +68,17 @@ flags = {}
 
 
 ## Configuration from file
-Config = ConfigParser.ConfigParser()
+Config = configparser.ConfigParser()
 Config.read('macsim.config')
-flags['dram']          = Config.get('Library', 'dram', '0')
-flags['power']         = Config.get('Library', 'power', '0')
-flags['iris']          = Config.get('Library', 'iris', '0')
-flags['qsim']          = Config.get('Library', 'qsim', '0')
-flags['debug']         = Config.get('Build', 'debug', '0')
-flags['gprof']         = Config.get('Build', 'gprof', '0')
-flags['pin_3_13_trace'] = Config.get('Build', 'pin_3_13_trace', '0')
-flags['val']           = Config.get('Build_Extra', 'val', '0')
-flags['ramulator']     = Config.get('Library', 'ramulator', '0')
+flags['dram']          = Config.get('Library', 'dram', fallback='0')
+flags['power']         = Config.get('Library', 'power', fallback='0')
+flags['iris']          = Config.get('Library', 'iris', fallback='0')
+flags['qsim']          = Config.get('Library', 'qsim', fallback='0')
+flags['debug']         = Config.get('Build', 'debug', fallback='0')
+flags['gprof']         = Config.get('Build', 'gprof', fallback='0')
+flags['pin_3_13_trace'] = Config.get('Build', 'pin_3_13_trace', fallback='0')
+flags['val']           = Config.get('Build_Extra', 'val', fallback='0')
+flags['ramulator']     = Config.get('Library', 'ramulator', fallback='0')
 
 ## Configuration from commandline
 flags['debug']         = ARGUMENTS.get('debug', flags['debug'])

--- a/build.py
+++ b/build.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 #########################################################################################
 # Author      : Jaekyu Lee (jq.lee17@gmail.com)

--- a/build.py
+++ b/build.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 
 #########################################################################################
 # Author      : Jaekyu Lee (jq.lee17@gmail.com)

--- a/src/trace_read.cc
+++ b/src/trace_read.cc
@@ -697,11 +697,11 @@ trace_reader_wrapper_c::trace_reader_wrapper_c(macsim_c *simBase) {
 }
 
 trace_reader_wrapper_c::trace_reader_wrapper_c() {
-  m_dprint_output->close();
-  delete m_dprint_output;
 }
 
 trace_reader_wrapper_c::~trace_reader_wrapper_c() {
+  m_dprint_output->close();
+  delete m_dprint_output;
   delete m_cpu_decoder;
   delete m_gpu_decoder;
 }


### PR DESCRIPTION
Not sure why it is complaining only now... seems like a very old issue.

g++ -o .opt_build/src/trace_read.o -c -O3 -std=c++14 -funroll-loops -Werror -Wuninitialized -Wno-write-strings -DLONG_COUNTERS -DNO_MPI -DNO_DEBUG -Isrc src/trace_read.cc
src/trace_read.cc: In constructor 'trace_reader_wrapper_c::trace_reader_wrapper_c()':
src/trace_read.cc:700:3: error: '*<unknown>.trace_reader_wrapper_c::m_dprint_output' is used uninitialized in this function [-Werror=uninitialized]
   m_dprint_output->close();
   ^~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
scons: *** [.opt_build/src/trace_read.o] Error 1